### PR TITLE
Add OS X support

### DIFF
--- a/src/cl_h.rs
+++ b/src/cl_h.rs
@@ -431,8 +431,8 @@ pub static CL_PROFILING_COMMAND_END:                     cl_uint = 0x1283;
 
 
 //#[link_args = "-L$OPENCL_LIB -lOpenCL"]
-#[link(name = "OpenCL")]
-#[cfg(target_os = "linux")]
+#[cfg_attr(target_os = "macos", link(name = "OpenCL", kind = "framework"))]
+#[cfg_attr(not(target_os = "macos"), link(name = "OpenCL"))]
 extern {
     // Platform API
     pub fn clGetPlatformIDs(num_entries:   cl_uint,


### PR DESCRIPTION
OpenCL is made available as a framework on Mac OS X
